### PR TITLE
Se implementa funcion que crea las funcionalidades del ayudante

### DIFF
--- a/app/controllers/curso_alumnos_controller.rb
+++ b/app/controllers/curso_alumnos_controller.rb
@@ -130,6 +130,7 @@ class CursoAlumnosController < ApplicationController
     end
     respond_to do |format|
       if @curso_alumno.update(curso_alumno_params)
+        @curso_alumno.crear_funcionalidades #!< se crean las funcionalidades del ayudante
         format.html { redirect_to @curso_alumno, notice: 'Grupo alumno was successfully updated.' }
         format.json { render :show, status: :ok, location: @curso_alumno }
       else

--- a/app/models/curso_alumno.rb
+++ b/app/models/curso_alumno.rb
@@ -2,4 +2,26 @@ class CursoAlumno < ActiveRecord::Base
   belongs_to :grupo
   belongs_to :curso
   belongs_to :alumno, class_name: 'Alumno'
+  has_many :funcionalidades, class_name: 'FuncionalidadAyudanteCurso'
+
+  def crear_funcionalidades
+    begin
+      CursoAlumno.transaction do 
+        func = Funcionalidad.all
+
+        func.each do |f|
+          self.funcionalidades.create(
+            permitido: false,
+            funcionalidad_id: f.id
+          )
+        end 
+      end
+    rescue => e
+      raise ActiveRecord::Rollback
+    end
+  end
+
+  def eliminar_funcionalidades
+    self.funcionalidades.destroy_all
+  end
 end

--- a/db/migrate/20160106065802_add_column_to_fac.rb
+++ b/db/migrate/20160106065802_add_column_to_fac.rb
@@ -1,0 +1,5 @@
+class AddColumnToFac < ActiveRecord::Migration
+  def change
+    add_column :funcionalidad_ayudante_cursos, :permitido, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160106051501) do
+ActiveRecord::Schema.define(version: 20160106065802) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -82,6 +82,7 @@ ActiveRecord::Schema.define(version: 20160106051501) do
     t.integer  "funcionalidad_id"
     t.datetime "created_at",       null: false
     t.datetime "updated_at",       null: false
+    t.boolean  "permitido"
   end
 
   create_table "funcionalidads", force: :cascade do |t|


### PR DESCRIPTION
El método lo que hace es llenar la tabla `funcionalidad_ayudante_cursos` con 
todas las funcionalidades disponibles pero con la columna de `permitido` en 
`false` (por defecto no tiene ningun permiso sobre el curso).

Análogamente se crea un método para eliminar todas las funcionalidades 
asignadas al ayudante en caso que se "desasigne" al curso.
