### PR TITLE
Se muestran las preguntas dentro del mismo .json de la encuesta

### DIFF
--- a/app/models/encuesta_preguntum.rb
+++ b/app/models/encuesta_preguntum.rb
@@ -1,4 +1,4 @@
 class EncuestaPreguntum < ActiveRecord::Base
-	belongs_to :encuestum
-	belongs_to :preguntum
+  belongs_to :encuestum
+  belongs_to :pregunta, class_name: "Preguntum", foreign_key: "pregunta_id"
 end

--- a/app/models/encuestum.rb
+++ b/app/models/encuestum.rb
@@ -1,5 +1,6 @@
 class Encuestum < ActiveRecord::Base
-  has_many :encuesta_preguntums
+  has_many :_preguntas, class_name: "EncuestaPreguntum", foreign_key: "encuesta_id"
+  has_many :preguntas, through: :_preguntas, source: :pregunta
   has_many :evaluaciones
   belongs_to :tipo_encuestum
   has_many :encuesta_alumnos

--- a/app/views/encuesta/show.json.jbuilder
+++ b/app/views/encuesta/show.json.jbuilder
@@ -1,1 +1,1 @@
-json.extract! @encuestum, :id, :estado, :nombre, :descripcion, :tipo_encuesta_id, :created_at, :updated_at, :profesor_id
+json.extract! @encuestum, :id, :estado, :nombre, :descripcion, :tipo_encuesta_id, :preguntas, :created_at, :updated_at, :profesor_id


### PR DESCRIPTION
Las preguntas se colocan dentro de .json de la encuesta como un arreglo.
Es decir el .json de una encuesta en particular se verá algo como:

``` json
{
 "id":2,
 "estado":true,
 "nombre":"Encuesta IHC 360 semestre 2",
 "descripcion":"Contesten la encuesta",
 "tipo_encuesta_id":1,
 "preguntas":[{"id":1,
           "enunciado":"¿Como se llama?",
           "created_at":"2016-01-17T05:20:41.085Z",
           "updated_at":"2016-01-17T05:20:41.085Z"
           },
          {"id":3,
           "enunciado":"¿Como se llaman?",
           "created_at":"2016-01-17T05:20:41.108Z",
           "updated_at":"2016-01-17T05:20:41.108Z"
          }],
 "created_at":"2016-01-17T05:20:41.025Z",
 "updated_at":"2016-01-17T05:20:41.025Z",
 "profesor_id":null
}
```
